### PR TITLE
Fix PHP instructions position from the <?php anchor

### DIFF
--- a/signup.php
+++ b/signup.php
@@ -45,7 +45,7 @@ if(isset($_SESSION["connexionNeeded"])){
                                 echo 'checked="checked"';
                             }
                             ?>>
-                        <?php// echo ($key == $defaultGender)?'checked="checked"':""; ?>
+                        <?php // echo ($key == $defaultGender)?'checked="checked"':""; ?>
                         <?php echo $value; ?>
                     </label>
                 </div>


### PR DESCRIPTION
The PHP instructions at line 48 (actually a commentary) touch the `<?php` anchor which returns a syntax error in some IDE.

Demonstration in [Visual Studio Code](https://code.visualstudio.com/) :

![demovs](https://i.imgur.com/DUvx8ls.png)